### PR TITLE
Update process_file.py

### DIFF
--- a/scraps/process_file.py
+++ b/scraps/process_file.py
@@ -53,12 +53,12 @@ def process_file(fileName, mask = None, meta_only=False, **loadtxt_kwargs):
 
     #Read the temp, pwr, and resName from the filename
     if(fileName[tempLoc + 1] == '.'):
-        temp = np.float(fileName[tempLoc:tempLoc+5])
+        temp = float(fileName[tempLoc:tempLoc+5])
 
         if fileName[pwrLoc] == '_':
-            pwr = np.float(fileName[pwrLoc+1:pwrLoc+3])
+            pwr = float(fileName[pwrLoc+1:pwrLoc+3])
         else:
-            pwr = np.float(fileName[pwrLoc:pwrLoc+3])
+            pwr = float(fileName[pwrLoc:pwrLoc+3])
 
         resName = fileName[resNameLoc:resNameLoc+5]
 


### PR DESCRIPTION
Changing from "np.float" to the built-in "float", since the numpy alias has been deprecated since 1.20, and has been stopping compilation in Python 3.11.4 kernels using VS Code.

The change should be safe and otherwise inconsequential, pending verification.